### PR TITLE
feat: npmプロジェクトをGUIで直接指定できるようにする

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1813,6 +1813,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
 name = "objc_exception"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,6 +2386,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2571463863a6bd50c32f94402933f03457a3fbaf697a707c5be741e459f08fd"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "rfd"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0149778bd99b6959285b0933288206090c50e2327f47a9c463bfdbf45c8823ea"
+dependencies = [
+ "block",
+ "dispatch",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.37.0",
 ]
 
 [[package]]
@@ -2956,6 +2991,7 @@ dependencies = [
  "rand 0.8.5",
  "raw-window-handle",
  "regex",
+ "rfd",
  "semver",
  "serde",
  "serde_json",
@@ -3597,6 +3633,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3624,6 +3672,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+
+[[package]]
+name = "web-sys"
+version = "0.3.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "webkit2gtk"
@@ -3743,6 +3801,19 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b543186b344cc61c85b5aab0d2e3adf4e0f99bc076eff9aa5927bcc0b8a647"
+dependencies = [
+ "windows_aarch64_msvc 0.37.0",
+ "windows_i686_gnu 0.37.0",
+ "windows_i686_msvc 0.37.0",
+ "windows_x86_64_gnu 0.37.0",
+ "windows_x86_64_msvc 0.37.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c4bd0a50ac6020f65184721f758dba47bb9fbc2133df715ec74a237b26794a"
@@ -3858,6 +3929,12 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
@@ -3873,6 +3950,12 @@ name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3894,6 +3977,12 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
@@ -3909,6 +3998,12 @@ name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3939,6 +4034,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-tauri = { version = "1.5", features = ["shell-open"] }
+tauri = { version = "1.5", features = [ "dialog-open", "shell-open"] }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.35.1", features = ["full"] }
 serde_json = "1.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,6 +16,9 @@
       "shell": {
         "all": false,
         "open": true
+      },
+      "dialog": {
+        "open": true
       }
     },
     "bundle": {

--- a/src/app.vue
+++ b/src/app.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { invoke } from '@tauri-apps/api'
 import type { InlineAlert } from '~/components/domains/InlineAlert/privates/alert';
+import { open } from '@tauri-apps/api/dialog';
 
 const defaultProjectName = '無題のプロジェクト'
 const projectName = ref(defaultProjectName)
@@ -82,6 +83,16 @@ const dirUpdated = computed<string>({
     }
   }
 })
+
+async function getDirBySelect() {
+  const directoryPath = await open({
+    directory: true,
+    multiple: false
+  })
+  if (directoryPath && typeof directoryPath === 'string') {
+    dirUpdated.value = directoryPath
+  }
+}
 </script>
 
 <template>
@@ -98,11 +109,16 @@ const dirUpdated = computed<string>({
       </button>
     </template>
     <template v-else>
-      <TextInput
-        class="header__project_dir"
-        :model-value="dir"
-        placeholder="npmプロジェクトを入力..."
-        @update:model-value="dirUpdated = $event" />
+      <div class="header__project_dir">
+        <Button @click="getDirBySelect">
+          ディレクトリを選択
+        </Button>
+        <TextInput
+          class="header__directory_input"
+          :model-value="dir"
+          placeholder="npmプロジェクトを直接入力..."
+          @update:model-value="dirUpdated = $event" />
+      </div>
     </template>
     <template v-if="alert">
       <InlineAlert :alert="alert" />
@@ -127,7 +143,11 @@ const dirUpdated = computed<string>({
 }
 
 .header__project_dir {
-  @apply w-full mt-2;
+  @apply mt-2 flex flex-row;
+}
+
+.header__directory_input {
+  @apply ml-2 flex grow;
 }
 
 .header__project_dir_button {

--- a/src/app.vue
+++ b/src/app.vue
@@ -79,18 +79,22 @@ const dirUpdated = computed<string>({
     if (dir.value === '') {
       resetProjectMeta()
     } else {
-      updateProjectMeta(dir.value)
+      await updateProjectMeta(dir.value)
     }
   }
 })
 
 async function getDirBySelect() {
-  const directoryPath = await open({
-    directory: true,
-    multiple: false
-  })
-  if (directoryPath && typeof directoryPath === 'string') {
-    dirUpdated.value = directoryPath
+  try {
+    const directoryPath = await open({
+      directory: true,
+      multiple: false
+    })
+    if (directoryPath && typeof directoryPath === 'string') {
+      dirUpdated.value = directoryPath
+    }
+  } catch (e) {
+    alert.value = { status: 'error', message: 'ディレクトリの選択に失敗しました' }
   }
 }
 </script>

--- a/src/components/atoms/Button.vue
+++ b/src/components/atoms/Button.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <button type="button" class="button">
+    <slot />
+  </button>
+</template>
+
+<style scoped>
+/* TODO: ボタンのバリエーションが必要になったら動的なクラス定義を追加 */
+.button {
+  @apply bg-[#273c75] font-semibold text-white rounded px-4 py-3 hover:opacity-80;
+}
+</style>

--- a/src/components/atoms/TextInput.vue
+++ b/src/components/atoms/TextInput.vue
@@ -29,6 +29,6 @@ const value = computed({
 
 <style scoped>
 input {
-  @apply p-2 rounded bg-[#eeeeee];
+  @apply p-2 rounded border-[#273c75] border;
 }
 </style>


### PR DESCRIPTION
# 概要

テキストでしかnpmプロジェクトを選択できなかったため、一度CLIなどでディレクトリパスを知っている必要があった。

ディレクトリを画面上から直接探して選択できる機能を実装。合わせて、汎用的なボタンコンポーネントも新規で実装。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- アプリにディレクトリ選択機能を追加しました。
	- 新しいボタンコンポーネントを導入し、様々なスタイルバリエーションに対応しました。

- **スタイル**
	- ディレクトリエレメントのスタイリングを調整しました。
	- テキスト入力の境界線の色とスタイルを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->