### PR TITLE
refactor: 既存のカスタム色スキームを定数定義

### DIFF
--- a/src/components/atoms/Button.vue
+++ b/src/components/atoms/Button.vue
@@ -10,6 +10,6 @@
 <style scoped>
 /* TODO: ボタンのバリエーションが必要になったら動的なクラス定義を追加 */
 .button {
-  @apply bg-[#273c75] font-semibold text-white rounded px-4 py-3 hover:opacity-80;
+  @apply bg-blue-mazarine font-semibold text-white rounded px-4 py-3 hover:opacity-80;
 }
 </style>

--- a/src/components/atoms/TextInput.vue
+++ b/src/components/atoms/TextInput.vue
@@ -29,6 +29,6 @@ const value = computed({
 
 <style scoped>
 input {
-  @apply p-2 rounded border-[#273c75] border;
+  @apply p-2 rounded border-blue-mazarine border;
 }
 </style>

--- a/src/components/domains/InlineAlert/InlineAlert.vue
+++ b/src/components/domains/InlineAlert/InlineAlert.vue
@@ -38,6 +38,6 @@ const iconColor = computed(() => iconColors[props.alert.status])
 }
 
 .header__alert_text {
-  @apply text-[#666666] text-sm;
+  @apply text-gray-3 text-sm;
 }
 </style>

--- a/src/components/domains/ScriptsList.vue
+++ b/src/components/domains/ScriptsList.vue
@@ -41,7 +41,10 @@ async function executeScript(command: string) {
   isExecuting.value = false
 }
 
-function toIcon(code: number): { name: string, color: string } {
+/**
+ * 終了コードから表示するアイコンを解決する
+ */
+function resolveIcon(code: number): { name: string, color: string } {
   return code === 0 ? {
     name: 'mdi:check',
     color: '#22C55E'
@@ -54,6 +57,11 @@ function toIcon(code: number): { name: string, color: string } {
 const classes = computed(() => ({
   'card__button--disabled': isExecuting.value
 }))
+
+watch(props.scripts, () => {
+  // 別のプロジェクトが読み込まれたらステータスを初期化し直し
+  exitStatuses.value = {}
+})
 </script>
 
 <template>
@@ -71,8 +79,8 @@ const classes = computed(() => ({
             <template v-if="exitStatuses[command] != undefined">
               <div class="card__status">
                 <Icon
-                  :name="toIcon(exitStatuses[command]).name"
-                  :color="toIcon(exitStatuses[command]).color"
+                  :name="resolveIcon(exitStatuses[command]).name"
+                  :color="resolveIcon(exitStatuses[command]).color"
                   />
               </div>
             </template>
@@ -85,7 +93,7 @@ const classes = computed(() => ({
 
 <style>
 .card {
-  @apply bg-[#eeeeee] rounded mb-2 hover:bg-[#dddddd] hover:cursor-pointer;
+  @apply bg-gray-1 rounded mb-2 hover:bg-gray-2 hover:cursor-pointer;
 }
 
 .card__button {
@@ -93,7 +101,7 @@ const classes = computed(() => ({
 }
 
 .card__button--disabled {
-  @apply bg-[#dddddd] text-[#666666];
+  @apply bg-gray-2 text-gray-3;
 }
 
 .card__title {

--- a/src/components/domains/ScriptsStdout.vue
+++ b/src/components/domains/ScriptsStdout.vue
@@ -37,7 +37,7 @@ function toLines(text: string): string[] {
 
 <style>
 .scripts__stdout {
-  @apply bg-[#002451] flex-1 ml-8 rounded w-full overflow-y-scroll;
+  @apply bg-blue-tomorrow-night flex-1 ml-8 rounded w-full overflow-y-scroll;
 }
 
 .scripts__stdout_text {

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -1,0 +1,14 @@
+export default {
+  gray: {
+    1: "#EEEEEE",
+    2: "#DDDDDD",
+    3: "#666666"
+  },
+  blue: {
+    "tomorrow-night": "#002451",
+    // https://flatuicolors.com/palette/gb
+    mazarine: "#273c75"
+  },
+  success: "22C55E",
+  danger: "EF4444",
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,7 @@
+const { resolve } = require('path')
+const colorsPath = resolve(__dirname, 'src/styles/colors.ts')
+const colors = require(colorsPath)
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
@@ -9,7 +13,9 @@ export default {
     "./app.vue",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
# 概要

ベタ書きしてしまっていた色の定義を定数化。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイルの変更**
	- ボタンの背景色をマザリンブルーに変更しました。
	- テキスト入力フィールドのボーダー色をマザリンブルーに更新しました。
	- インラインアラートのテキスト色をグレー3に変更しました。
	- スクリプトの標準出力部分の背景色をトゥモローナイトブルーに変更しました。

- **新機能**
	- アプリケーションの各要素の色定義を追加しました。

- **バグ修正**
	- スクリプトリストが異なるプロジェクトを読み込んだ時に `exitStatuses` を初期化するように修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->